### PR TITLE
远程启动持续时长持久化

### DIFF
--- a/custom_components/volvooncall_cn/number.py
+++ b/custom_components/volvooncall_cn/number.py
@@ -1,4 +1,5 @@
 import logging
+from propcache import cached_property
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -6,7 +7,6 @@ from homeassistant.components.number import NumberEntity
 from homeassistant.const import Platform
 from . import VolvoCoordinator, VolvoEntity
 from .volvooncall_cn import DOMAIN
-from propcache import cached_property
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,34 +32,29 @@ class VolovEngineDurationNumInput(VolvoEntity, NumberEntity):
         self.max_duration = 15
         self.min_duration = 1
 
-    @property
-    def max_value(self) -> float:
-        return self.max_duration
-
     @cached_property
     def native_max_value(self) -> float:
         return self.max_duration
-
-    @property
-    def min_value(self):
-        return self.min_duration
 
     @cached_property
     def native_min_value(self) -> float:
         return self.min_duration
 
-    @property
-    def step(self):
-        return 1
-
     @cached_property
     def native_step(self) -> float:
         return 1
 
-    @property
-    def value(self):
-        return self.coordinator.data[self.idx].get_engine_duration()
+    @cached_property
+    def native_value(self):
+       store_data = self.coordinator.store_datas[self.idx]
+       return store_data.get_engine_duration_number()
 
-    async def async_set_value(self, value):
-        await self.coordinator.data[self.idx].set_engine_duration(value)
+    @property
+    def state(self):
+        store_data = self.coordinator.store_datas[self.idx]
+        return store_data.get_engine_duration_number()
+
+    async def async_set_native_value(self, value):
+        store_data = self.coordinator.store_datas[self.idx]
+        await store_data.set_engine_duration_number(value)
         await self.coordinator.async_refresh()

--- a/custom_components/volvooncall_cn/proto/engineremotestart.proto
+++ b/custom_components/volvooncall_cn/proto/engineremotestart.proto
@@ -46,8 +46,8 @@ message GetEngineRemoteStartData {
   Timestamp updateTime = 1;
   EngineRunningStatus engineRunningStatus = 2;
   EngineErrorType engineError = 3;
-  int64 engineStartTime = 4;
-  int64 engineEndTime = 5;
+  Timestamp engineStartTime = 4;
+  Timestamp engineEndTime = 5;
 
 }
 message GetEngineRemoteStartResp {

--- a/custom_components/volvooncall_cn/proto/engineremotestart_pb2.py
+++ b/custom_components/volvooncall_cn/proto/engineremotestart_pb2.py
@@ -24,25 +24,25 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x17\x65ngineremotestart.proto\x12(services.vehiclestates.engineremotestart\"&\n\x17GetEngineRemoteStartReq\x12\x0b\n\x03vin\x18\x02 \x01(\t\"+\n\tTimestamp\x12\x0f\n\x07seconds\x18\x01 \x01(\x03\x12\r\n\x05nanos\x18\x02 \x01(\x03\"\xbf\x02\n\x18GetEngineRemoteStartData\x12G\n\nupdateTime\x18\x01 \x01(\x0b\x32\x33.services.vehiclestates.engineremotestart.Timestamp\x12Z\n\x13\x65ngineRunningStatus\x18\x02 \x01(\x0e\x32=.services.vehiclestates.engineremotestart.EngineRunningStatus\x12N\n\x0b\x65ngineError\x18\x03 \x01(\x0e\x32\x39.services.vehiclestates.engineremotestart.EngineErrorType\x12\x17\n\x0f\x65ngineStartTime\x18\x04 \x01(\x03\x12\x15\n\rengineEndTime\x18\x05 \x01(\x03\"y\n\x18GetEngineRemoteStartResp\x12\x0b\n\x03vin\x18\x02 \x01(\t\x12P\n\x04\x64\x61ta\x18\x03 \x01(\x0b\x32\x42.services.vehiclestates.engineremotestart.GetEngineRemoteStartData*\xc4\x02\n\x0f\x45ngineErrorType\x12\x0f\n\x0bUnspecifid1\x10\x00\x12\x16\n\x12\x45xceededMaxAttempt\x10\x01\x12\x0f\n\x0b\x43\x61rUnLocked\x10\x02\x12\x0c\n\x08KeyInCar\x10\x03\x12\x0c\n\x08\x44oorOpen\x10\x04\x12\x0c\n\x08HoodOpen\x10\x05\x12\x11\n\rIncorrectGear\x10\x06\x12\x0f\n\x0bPersonInCar\x10\x07\x12\x10\n\x0cPedalPressed\x10\x08\x12\x0b\n\x07LowFuel\x10\t\x12\x0e\n\nLowBattery\x10\n\x12\x15\n\x11LowBatteryAndFuel\x10\x0b\x12\x12\n\x0e\x43hargerPlugged\x10\x0c\x12\x16\n\x12\x45ngineCoolantFault\x10\r\x12\x17\n\x13\x42\x61tteryCoolantFault\x10\x0e\x12\x13\n\x0fServiceRequired\x10\x0f\x12\t\n\x05Other\x10\x10*X\n\x13\x45ngineRunningStatus\x12\x0f\n\x0bUnspecifid2\x10\x00\x12\x07\n\x03Off\x10\x01\x12\x0c\n\x08Starting\x10\x02\x12\x0b\n\x07Running\x10\x03\x12\x0c\n\x08Stopping\x10\x04\x32\xbe\x01\n\x18\x45ngineRemoteStartService\x12\xa1\x01\n\x14GetEngineRemoteStart\x12\x41.services.vehiclestates.engineremotestart.GetEngineRemoteStartReq\x1a\x42.services.vehiclestates.engineremotestart.GetEngineRemoteStartResp\"\x00\x30\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x17\x65ngineremotestart.proto\x12(services.vehiclestates.engineremotestart\"&\n\x17GetEngineRemoteStartReq\x12\x0b\n\x03vin\x18\x02 \x01(\t\"+\n\tTimestamp\x12\x0f\n\x07seconds\x18\x01 \x01(\x03\x12\r\n\x05nanos\x18\x02 \x01(\x03\"\xa9\x03\n\x18GetEngineRemoteStartData\x12G\n\nupdateTime\x18\x01 \x01(\x0b\x32\x33.services.vehiclestates.engineremotestart.Timestamp\x12Z\n\x13\x65ngineRunningStatus\x18\x02 \x01(\x0e\x32=.services.vehiclestates.engineremotestart.EngineRunningStatus\x12N\n\x0b\x65ngineError\x18\x03 \x01(\x0e\x32\x39.services.vehiclestates.engineremotestart.EngineErrorType\x12L\n\x0f\x65ngineStartTime\x18\x04 \x01(\x0b\x32\x33.services.vehiclestates.engineremotestart.Timestamp\x12J\n\rengineEndTime\x18\x05 \x01(\x0b\x32\x33.services.vehiclestates.engineremotestart.Timestamp\"y\n\x18GetEngineRemoteStartResp\x12\x0b\n\x03vin\x18\x02 \x01(\t\x12P\n\x04\x64\x61ta\x18\x03 \x01(\x0b\x32\x42.services.vehiclestates.engineremotestart.GetEngineRemoteStartData*\xc4\x02\n\x0f\x45ngineErrorType\x12\x0f\n\x0bUnspecifid1\x10\x00\x12\x16\n\x12\x45xceededMaxAttempt\x10\x01\x12\x0f\n\x0b\x43\x61rUnLocked\x10\x02\x12\x0c\n\x08KeyInCar\x10\x03\x12\x0c\n\x08\x44oorOpen\x10\x04\x12\x0c\n\x08HoodOpen\x10\x05\x12\x11\n\rIncorrectGear\x10\x06\x12\x0f\n\x0bPersonInCar\x10\x07\x12\x10\n\x0cPedalPressed\x10\x08\x12\x0b\n\x07LowFuel\x10\t\x12\x0e\n\nLowBattery\x10\n\x12\x15\n\x11LowBatteryAndFuel\x10\x0b\x12\x12\n\x0e\x43hargerPlugged\x10\x0c\x12\x16\n\x12\x45ngineCoolantFault\x10\r\x12\x17\n\x13\x42\x61tteryCoolantFault\x10\x0e\x12\x13\n\x0fServiceRequired\x10\x0f\x12\t\n\x05Other\x10\x10*X\n\x13\x45ngineRunningStatus\x12\x0f\n\x0bUnspecifid2\x10\x00\x12\x07\n\x03Off\x10\x01\x12\x0c\n\x08Starting\x10\x02\x12\x0b\n\x07Running\x10\x03\x12\x0c\n\x08Stopping\x10\x04\x32\xbe\x01\n\x18\x45ngineRemoteStartService\x12\xa1\x01\n\x14GetEngineRemoteStart\x12\x41.services.vehiclestates.engineremotestart.GetEngineRemoteStartReq\x1a\x42.services.vehiclestates.engineremotestart.GetEngineRemoteStartResp\"\x00\x30\x01\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'engineremotestart_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
-  _globals['_ENGINEERRORTYPE']._serialized_start=600
-  _globals['_ENGINEERRORTYPE']._serialized_end=924
-  _globals['_ENGINERUNNINGSTATUS']._serialized_start=926
-  _globals['_ENGINERUNNINGSTATUS']._serialized_end=1014
+  _globals['_ENGINEERRORTYPE']._serialized_start=706
+  _globals['_ENGINEERRORTYPE']._serialized_end=1030
+  _globals['_ENGINERUNNINGSTATUS']._serialized_start=1032
+  _globals['_ENGINERUNNINGSTATUS']._serialized_end=1120
   _globals['_GETENGINEREMOTESTARTREQ']._serialized_start=69
   _globals['_GETENGINEREMOTESTARTREQ']._serialized_end=107
   _globals['_TIMESTAMP']._serialized_start=109
   _globals['_TIMESTAMP']._serialized_end=152
   _globals['_GETENGINEREMOTESTARTDATA']._serialized_start=155
-  _globals['_GETENGINEREMOTESTARTDATA']._serialized_end=474
-  _globals['_GETENGINEREMOTESTARTRESP']._serialized_start=476
-  _globals['_GETENGINEREMOTESTARTRESP']._serialized_end=597
-  _globals['_ENGINEREMOTESTARTSERVICE']._serialized_start=1017
-  _globals['_ENGINEREMOTESTARTSERVICE']._serialized_end=1207
+  _globals['_GETENGINEREMOTESTARTDATA']._serialized_end=580
+  _globals['_GETENGINEREMOTESTARTRESP']._serialized_start=582
+  _globals['_GETENGINEREMOTESTARTRESP']._serialized_end=703
+  _globals['_ENGINEREMOTESTARTSERVICE']._serialized_start=1123
+  _globals['_ENGINEREMOTESTARTSERVICE']._serialized_end=1313
 # @@protoc_insertion_point(module_scope)

--- a/custom_components/volvooncall_cn/proto/engineremotestart_pb2.pyi
+++ b/custom_components/volvooncall_cn/proto/engineremotestart_pb2.pyi
@@ -79,9 +79,9 @@ class GetEngineRemoteStartData(_message.Message):
     updateTime: Timestamp
     engineRunningStatus: EngineRunningStatus
     engineError: EngineErrorType
-    engineStartTime: int
-    engineEndTime: int
-    def __init__(self, updateTime: _Optional[_Union[Timestamp, _Mapping]] = ..., engineRunningStatus: _Optional[_Union[EngineRunningStatus, str]] = ..., engineError: _Optional[_Union[EngineErrorType, str]] = ..., engineStartTime: _Optional[int] = ..., engineEndTime: _Optional[int] = ...) -> None: ...
+    engineStartTime: Timestamp
+    engineEndTime: Timestamp
+    def __init__(self, updateTime: _Optional[_Union[Timestamp, _Mapping]] = ..., engineRunningStatus: _Optional[_Union[EngineRunningStatus, str]] = ..., engineError: _Optional[_Union[EngineErrorType, str]] = ..., engineStartTime: _Optional[_Union[Timestamp, _Mapping]] = ..., engineEndTime: _Optional[_Union[Timestamp, _Mapping]] = ...) -> None: ...
 
 class GetEngineRemoteStartResp(_message.Message):
     __slots__ = ("vin", "data")

--- a/custom_components/volvooncall_cn/proto/engineremotestart_pb2_grpc.py
+++ b/custom_components/volvooncall_cn/proto/engineremotestart_pb2_grpc.py
@@ -35,10 +35,10 @@ class EngineRemoteStartServiceStub(object):
             channel: A grpc.Channel.
         """
         self.GetEngineRemoteStart = channel.unary_stream(
-            '/services.vehiclestates.engineremotestart.EngineRemoteStartService/GetEngineRemoteStart',
-            request_serializer=engineremotestart__pb2.GetEngineRemoteStartReq.SerializeToString,
-            response_deserializer=engineremotestart__pb2.GetEngineRemoteStartResp.FromString,
-            _registered_method=True)
+                '/services.vehiclestates.engineremotestart.EngineRemoteStartService/GetEngineRemoteStart',
+                request_serializer=engineremotestart__pb2.GetEngineRemoteStartReq.SerializeToString,
+                response_deserializer=engineremotestart__pb2.GetEngineRemoteStartResp.FromString,
+                _registered_method=True)
 
 
 class EngineRemoteStartServiceServicer(object):
@@ -53,35 +53,33 @@ class EngineRemoteStartServiceServicer(object):
 
 def add_EngineRemoteStartServiceServicer_to_server(servicer, server):
     rpc_method_handlers = {
-        'GetEngineRemoteStart': grpc.unary_stream_rpc_method_handler(
-            servicer.GetEngineRemoteStart,
-            request_deserializer=engineremotestart__pb2.GetEngineRemoteStartReq.FromString,
-            response_serializer=engineremotestart__pb2.GetEngineRemoteStartResp.SerializeToString,
-        ),
+            'GetEngineRemoteStart': grpc.unary_stream_rpc_method_handler(
+                    servicer.GetEngineRemoteStart,
+                    request_deserializer=engineremotestart__pb2.GetEngineRemoteStartReq.FromString,
+                    response_serializer=engineremotestart__pb2.GetEngineRemoteStartResp.SerializeToString,
+            ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
-        'services.vehiclestates.engineremotestart.EngineRemoteStartService', rpc_method_handlers)
+            'services.vehiclestates.engineremotestart.EngineRemoteStartService', rpc_method_handlers)
     server.add_generic_rpc_handlers((generic_handler,))
-    server.add_registered_method_handlers(
-        'services.vehiclestates.engineremotestart.EngineRemoteStartService', rpc_method_handlers)
+    server.add_registered_method_handlers('services.vehiclestates.engineremotestart.EngineRemoteStartService', rpc_method_handlers)
+
 
  # This class is part of an EXPERIMENTAL API.
-
-
 class EngineRemoteStartService(object):
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod
     def GetEngineRemoteStart(request,
-                             target,
-                             options=(),
-                             channel_credentials=None,
-                             call_credentials=None,
-                             insecure=False,
-                             compression=None,
-                             wait_for_ready=None,
-                             timeout=None,
-                             metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_stream(
             request,
             target,

--- a/custom_components/volvooncall_cn/store.py
+++ b/custom_components/volvooncall_cn/store.py
@@ -1,0 +1,43 @@
+
+import logging
+from typing import TypedDict, Unpack
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+from .volvooncall_cn import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+STORE_VERSION = 1
+
+
+class StoreData(TypedDict, total=False):
+    """Volvo Store Data"""
+    engine_duration_number: int
+
+
+class VolvoStore(Store[StoreData]):
+    def __init__(self, hass: HomeAssistant, vin: str):
+        super().__init__(hass=hass, key=f"{DOMAIN}.{vin}", version=STORE_VERSION)
+        self.data: StoreData | None = None
+        self.default_data = StoreData(engine_duration_number=5)
+
+    def get(self, key):
+        assert self.data is not None
+        return self.data.get(key)
+
+    async def load_create_data(self) -> StoreData:
+        self.data = await self.async_load() or self.default_data
+        return self.data
+
+    async def update(self, **kwargs: Unpack[StoreData]):
+        self.data = self.data or await self.load_create_data()
+        for key, value in kwargs.items():
+            if value is not None and key in StoreData.__annotations__:
+                self.data[key] = value
+        await self.async_save(self.data)
+
+    def get_engine_duration_number(self):
+        self.data = self.data or self.default_data
+        return self.data.get("engine_duration_number")
+
+    async def set_engine_duration_number(self, value):
+        await self.update(engine_duration_number=int(value))

--- a/custom_components/volvooncall_cn/switch.py
+++ b/custom_components/volvooncall_cn/switch.py
@@ -58,7 +58,8 @@ class VolvoEngineSwitch(VolvoSwitchEntity):
         super().__init__(coordinator, idx, metaKey, check_meta_keys)
 
     async def async_turn_on(self) -> None:
-        await self.coordinator.data[self.idx].engine_start()
+        duration = self.coordinator.store_datas[self.idx].get_engine_duration_number()
+        await self.coordinator.data[self.idx].engine_start(duration)
         await self._update_status(True)
 
     async def async_turn_off(self) -> None:

--- a/custom_components/volvooncall_cn/volvooncall_cn.py
+++ b/custom_components/volvooncall_cn/volvooncall_cn.py
@@ -458,8 +458,8 @@ class Vehicle(object):
             self.engine_running = True
         else:
             self.engine_remote_running = False
-        self.engine_remote_start_time = engine_data.engineStartTime
-        self.engine_remote_end_time = engine_data.engineEndTime
+        self.engine_remote_start_time = engine_data.engineStartTime.seconds
+        self.engine_remote_end_time = engine_data.engineEndTime.seconds
 
     async def _parse_car_preference(self):
         try:

--- a/custom_components/volvooncall_cn/volvooncall_cn.py
+++ b/custom_components/volvooncall_cn/volvooncall_cn.py
@@ -54,7 +54,6 @@ class VehicleAPI(VehicleBaseAPI):
         self.channel_token: str = ""
         self.lbs_channel = None
         self.lbs_channel_token: str = ""
-        self.engine_duration = 5
 
     async def gen_channel(self, token, target):
         callCreds = grpc.access_token_call_credentials(token)
@@ -163,12 +162,11 @@ class VehicleAPI(VehicleBaseAPI):
             break
         return res
 
-    async def engine_control(self, vin, isStart: bool):
+    async def engine_control(self, vin, isStart: bool, duration: int):
         stub = InvocationServiceStub(self.channel)
         req_header = invocationHead(vin=vin)
         req = EngineStartReq()
         if isStart:
-            duration = int(self.engine_duration)
             req = EngineStartReq(head=req_header, isStart=isStart, startDurationMin=duration)
         else:
             req = EngineStartReq(head=req_header, isStart=isStart)
@@ -521,17 +519,11 @@ class Vehicle(object):
     async def honk(self):
         await self._api.honk_flash_control(self.vin, HonkFlashType.HONK)
 
-    async def engine_start(self):
-        await self._api.engine_control(self.vin, True)
+    async def engine_start(self, duration):
+        await self._api.engine_control(self.vin, True, duration)
 
     async def engine_stop(self):
-        await self._api.engine_control(self.vin, False)
-
-    async def set_engine_duration(self, durationMin):
-        self._api.engine_duration = durationMin
-
-    def get_engine_duration(self) -> float:
-        return self._api.engine_duration
+        await self._api.engine_control(self.vin, False, 0)
 
     def get(self, key):
         if not hasattr(self, key):


### PR DESCRIPTION
- 存储启动持续时长，修复重启hass时持续时长重置为5
- 修复获取远程启动的开始和结束时间