### PR TITLE
修复登陆错误问题

### DIFF
--- a/custom_components/volvooncall_cn/manifest.json
+++ b/custom_components/volvooncall_cn/manifest.json
@@ -14,7 +14,7 @@
         "grpcio>=1.67.1",
         "grpcio-tools>=1.67.1"
     ],
-    "version": "2.4.0",
+    "version": "2.4.1",
     "loggers": [
         "volvooncall_cn"
     ]

--- a/custom_components/volvooncall_cn/volvooncall_base.py
+++ b/custom_components/volvooncall_cn/volvooncall_base.py
@@ -25,7 +25,7 @@ DIGITALVOLVO_HEADERS = {
     "Accept-Language": "zh-CN,zh-Hans;q=0.9",
     "X-Ca-Version": "1.0",
     "x-sdk-content-sha256": "UNSIGNED-PAYLOAD",
-    "version": "5.51.1",
+    "version": "5.53.1",
     "Accept": "application/json; charset=utf-8",
 }
 

--- a/custom_components/volvooncall_cn/volvooncall_base.py
+++ b/custom_components/volvooncall_cn/volvooncall_base.py
@@ -25,7 +25,7 @@ DIGITALVOLVO_HEADERS = {
     "Accept-Language": "zh-CN,zh-Hans;q=0.9",
     "X-Ca-Version": "1.0",
     "x-sdk-content-sha256": "UNSIGNED-PAYLOAD",
-    "version": "5.27.0",
+    "version": "5.51.1",
     "Accept": "application/json; charset=utf-8",
 }
 

--- a/custom_components/volvooncall_cn/volvooncall_cn.py
+++ b/custom_components/volvooncall_cn/volvooncall_cn.py
@@ -37,7 +37,7 @@ _LOGGER = logging.getLogger(__name__)
 
 GRPC_DIGITALVOLVO_HOST = "cepmobtoken.prod.c3.volvocars.com.cn:443"
 GRPC_LBS_VOLVO_HOST = "cepmobtoken.lbs.prod.c3.volvocars.com.cn:443"
-USER_AGENT = "vca-android/5.51.1 grpc-java-okhttp/1.68.0"
+USER_AGENT = "vca-android/5.53.1 grpc-java-okhttp/1.68.0"
 MAX_RETRIES = 1
 TIMEOUT = datetime.timedelta(seconds=10)
 DOMAIN = "volvooncall_cn"

--- a/custom_components/volvooncall_cn/volvooncall_cn.py
+++ b/custom_components/volvooncall_cn/volvooncall_cn.py
@@ -55,8 +55,13 @@ class VehicleAPI(VehicleBaseAPI):
         self.lbs_channel = None
         self.lbs_channel_token: str = ""
 
+    def _metadata_callback(self, context, callback):
+        token = self._vocapi_access_token.strip()
+        metadata = [('authorization', f'Bearer {token}')]
+        callback(metadata, None)
+
     async def gen_channel(self, token, target):
-        callCreds = grpc.access_token_call_credentials(token)
+        callCreds = grpc.metadata_call_credentials(self._metadata_callback)
         sslCreds = grpc.ssl_channel_credentials()
         creds = grpc.composite_channel_credentials(sslCreds, callCreds)
         channel_options: tuple = (("grpc.primary_user_agent", USER_AGENT), ('grpc.accept_encoding', 'gzip'),)

--- a/custom_components/volvooncall_cn/volvooncall_cn.py
+++ b/custom_components/volvooncall_cn/volvooncall_cn.py
@@ -51,16 +51,16 @@ class VehicleAPI(VehicleBaseAPI):
     def __init__(self, session, username, password):
         super(VehicleAPI, self).__init__(session, username, password)
         self.channel = None
-        self.channel_token: str = ""
         self.lbs_channel = None
-        self.lbs_channel_token: str = ""
+        self._channel_lock = asyncio.Lock()
+        self._lbs_channel_lock = asyncio.Lock()
 
     def _metadata_callback(self, context, callback):
         token = self._vocapi_access_token.strip()
         metadata = [('authorization', f'Bearer {token}')]
         callback(metadata, None)
 
-    async def gen_channel(self, token, target):
+    async def gen_channel(self, target):
         callCreds = grpc.metadata_call_credentials(self._metadata_callback)
         sslCreds = grpc.ssl_channel_credentials()
         creds = grpc.composite_channel_credentials(sslCreds, callCreds)
@@ -69,16 +69,20 @@ class VehicleAPI(VehicleBaseAPI):
         return channel
 
     async def get_channel(self):
-        if self.channel and self.channel_token == self._vocapi_access_token.strip():
+        if self.channel:
             return
-        self.channel_token = self._vocapi_access_token.strip()
-        self.channel = await self.gen_channel(self.channel_token, GRPC_DIGITALVOLVO_HOST)
+
+        async with self._channel_lock:
+            if not self.channel:
+                self.channel = await self.gen_channel(GRPC_DIGITALVOLVO_HOST)
 
     async def get_lbs_channel(self):
-        if self.lbs_channel and self.lbs_channel_token == self._vocapi_access_token.strip():
+        if self.lbs_channel:
             return
-        self.lbs_channel_token = self._vocapi_access_token.strip()
-        self.lbs_channel = await self.gen_channel(self.lbs_channel_token, GRPC_LBS_VOLVO_HOST)
+        
+        async with self._lbs_channel_lock:
+            if not self.lbs_channel:
+                self.lbs_channel = await self.gen_channel(GRPC_LBS_VOLVO_HOST)
 
     def raise_invocation_fail(self, status):
         if status in [invocationStatus.SUCCESS, invocationStatus.SENT, invocationStatus.DELIVERED]:


### PR DESCRIPTION
1. 更新 version，用于修复获取了错误的 jwt
2. channel 初始化时加锁处理，防止并发问题
3. grpc 的 authorization 改成 metadata callback 形式读取，每次都取最新 token